### PR TITLE
Fix side effect when confirming code on SignupConfirm

### DIFF
--- a/features.md
+++ b/features.md
@@ -53,8 +53,8 @@ Additionaly, when all needed methods are implemented convert service to a cloud 
 - On Error then show signup error message 20/02
 - On success redirect to Signup confirm  20/02
 
-NOTES RE SIGNUP
-- Firebase already hashes the password upon Signup. So no need for brypt and no need to store hashed password in DB 17/02
+NOTES RE SIGNUP 17/02
+- Firebase already hashes the password upon Signup. So no need for brypt and no need to store hashed password in DB 
 
 2. Logic for confirm sign up
 
@@ -66,6 +66,7 @@ NOTES RE SIGNUP
 - Be sure to set setSignupSuccess && setSignupSuccessFeedback back to null in code confirm logic Complete 23/02
 
 3. Logic for signin 
+- Create separate spinner state
 4. Logic for signout
 5. Logic Forgot Password 
 This section should have a two part flow. 1. The email is added to the input, 2. The confirm code ui form (Comp can only be accessed by initiating step 1). Make use of useNavigate
@@ -83,7 +84,7 @@ This section should have a two part flow. 1. The email is added to the input, 2.
 ### Feature 4 - User authentication alerts 
 0. NOTE: When implementing alerts here, try to incorporate the useTrasition hook to animate the mounting and unmounting of the alert. See if a lib like animate.js can be used. 
 1. Alerts sign up Complete 20/02
-2. Alerts confirm sign up
+2. Alerts confirm sign up Complete 23/02
 3. Alerts sign in
 - REMOVE bcrypt LOGIC FROM HERE => PASSWORDS ALREADY HASHED VIA FIREBASE
 4. Alerts sign out

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,6 +19,7 @@ function App() {
 	const isSignupConfirmError = useSelector(
 		(state) => state.auth.signupConfirmError
 	);
+	const isFormSubmitting = useSelector((state) => state.auth.isFormSubmitting);
 
 	return (
 		<BrowserRouter>
@@ -31,7 +32,7 @@ function App() {
 				<Route
 					path={'/auth/signup-confirm'}
 					element={
-						isSignupSuccess || isSignupConfirmError ? (
+						isSignupSuccess || isSignupConfirmError || isFormSubmitting ? (
 							<ConfirmSignUp
 								verifyAndUpdateUserEmail={verifyAndUpdateUserEmail}
 							/>

--- a/src/pages/ConfirmSignUp.jsx
+++ b/src/pages/ConfirmSignUp.jsx
@@ -95,7 +95,7 @@ const ConfirmSignUp = ({ verifyAndUpdateUserEmail }) => {
 				})
 			);
 
-			if (isSignupConfirmSuccess) {
+			if (isSignupConfirmSuccess && !isFormSubmitting) {
 				navigate('/auth/signin');
 				// return;
 			}

--- a/src/state/index.js
+++ b/src/state/index.js
@@ -1,9 +1,8 @@
 import { createSlice } from '@reduxjs/toolkit';
 
 const initialAuthState = {
-	// Auth form submissions
-	isFormSubmitting: false,
 	// SignUp
+	isFormSubmitting: false,
 	signupError: null,
 	signupErrorFeedback: null,
 	signupSuccess: null,


### PR DESCRIPTION
Spinner side effect when redirecting from Signup Confirm to Signin. The route for SignUp confirm is dynamic and required SignupSuccess or SignupConfirmError to be true. However, due to old state being cleared when SignupConfirmSuccess is true the condition for the dyanmic route (ConfirmSignup) is no longer true. Added new piece of state, if a form is submitting then remain on route. Side effect fixed. 